### PR TITLE
change auth-middleware behavior: authenticated by token user will replac...

### DIFF
--- a/django_token_auth/middleware.py
+++ b/django_token_auth/middleware.py
@@ -17,15 +17,12 @@ class TokenAuthenticationMiddleware(object):
             logger.warning("No API-TOKEN found in request. Skipping token authentication.")
             return None
 
-        if not hasattr(request, 'user') or not request.user.is_authenticated():
-            # Authenticate only if user didn't authenticate before
-            # We don't want to collide with django cookies auth needed for admin site for example
-            user = authenticate(token=token)
-            if not user:
-                logger.error("Unable to authenticate request. Invalid API-TOKEN.")
-                logger.debug("Invalid API-TOKEN: %s" % token)
-                # Continue the request flow, just remain user Anonymous
-                return None
-            else:
-                request.user = user
-                logger.info("Authenticated user `%s` by API-TOKEN" % request.user.username)
+        user = authenticate(token=token)
+        if not user:
+            logger.error("Unable to authenticate request. Invalid API-TOKEN.")
+            logger.debug("Invalid API-TOKEN: %s" % token)
+            # Continue the request flow, just remain user Anonymous
+            return None
+        else:
+            request.user = user
+            logger.info("Authenticated user `%s` by API-TOKEN" % request.user.username)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -33,7 +33,7 @@ class TokenAuthMiddlewareTestCase(TestCase):
 
     def test_already_authenticated_user(self):
         """
-            Should not replace existing authentication
+            Should replace existing authentication
         """
         token = 'API-TOKEN sometoken'
         request = self.factory.get('/', HTTP_AUTHORIZATION=token)
@@ -44,7 +44,7 @@ class TokenAuthMiddlewareTestCase(TestCase):
         TokenAuthenticationMiddleware().process_request(request)
 
         self.assertTrue(request.user.is_authenticated())
-        self.assertEqual(request.user.username, 'jahne')
+        self.assertEqual(request.user.username, 'john')
 
     def test_no_token(self):
         """


### PR DESCRIPTION
This change was caused by periodical confusing of anybody testing API. If the tester is logged in django-admin, the django-admin user displaces the token's one
